### PR TITLE
Add tests for getBetaFromDoubling()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,4 +25,6 @@ Imports:
     urlshorteneR,
     magrittr,
     tidyr
+Suggests:
+    testthat (>= 2.1.0)
 RoxygenNote: 7.1.0

--- a/R/helper.R
+++ b/R/helper.R
@@ -12,6 +12,12 @@ utils::globalVariables(c("Day", "value", "variable", "Date"))
 #' @param doubling.time Numeric.
 #' @param gamma Numeric.
 getBetaFromDoubling <- function(doubling.time, gamma) {
+  if (any(!is.na(doubling.time) & !is.numeric(doubling.time))) {
+    stop("Doubling time must be numeric", call. = FALSE)
+  }
+  if (any(!is.na(doubling.time) & doubling.time <= 0)) {
+    stop("Doubling time must be greater than zero", call. = FALSE)
+  }
   g <- 2 ^ (1 / doubling.time) - 1
   beta <- g + gamma
   return(beta)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(covidshiny)
+
+test_check("covidshiny")

--- a/tests/testthat/test-helper.R
+++ b/tests/testthat/test-helper.R
@@ -28,9 +28,13 @@ test_that("getBetaFromDoubling returns NA if either input is NA", {
   expect_true(is.na(b3))
 })
 
-test_that("getBetaFromDoubling gives meaningful result if doubling.time <= 0", {
-  b1 <- getBetaFromDoubling(0, 1)
-  b2 <- getBetaFromDoubling(-1, 1)
-  expect_equal(b1, Inf)
-  expect_equal(b2, 0.5)
+test_that("getBetaFromDoubling errors if doubling.time <= 0", {
+  expect_error(getBetaFromDoubling(0, 1))
+  expect_error(getBetaFromDoubling(-1, 1))
+  expect_error(getBetaFromDoubling(c(NA, -1), 1))
+})
+
+test_that("getBetaFromDoubling errors if doubling.time isn't numeric", {
+  expect_error(getBetaFromDoubling("foo", 1))
+  expect_error(getBetaFromDoubling(c(NA, "foo"), 1))
 })

--- a/tests/testthat/test-helper.R
+++ b/tests/testthat/test-helper.R
@@ -1,0 +1,36 @@
+context("Helpers")
+
+# getBetaFromDoubling ----------------------------------------------------------
+
+test_that("getBetaFromDoubling returns accurate results", {
+  b1 <- getBetaFromDoubling(doubling.time = 1, gamma = 1)
+  b2 <- getBetaFromDoubling(doubling.time = 4, gamma = 0.5)
+  expect_equal(b1, 2)
+  expect_equal(b2, 0.689207115002721)
+})
+
+test_that("getBetaFromDoubling can take multiple doubling times", {
+  betas <- getBetaFromDoubling(c(1, 1), 1)
+  expect_equal(betas, c(2, 2))
+})
+
+test_that("getBetaFromDoubling can take multiple gammas", {
+  betas <- getBetaFromDoubling(1, c(1, 2))
+  expect_equal(betas, c(2, 3))
+})
+
+test_that("getBetaFromDoubling returns NA if either input is NA", {
+  b1 <- getBetaFromDoubling(1, NA)
+  b2 <- getBetaFromDoubling(NA, 1)
+  b3 <- getBetaFromDoubling(NA, NA)
+  expect_true(is.na(b1))
+  expect_true(is.na(b2))
+  expect_true(is.na(b3))
+})
+
+test_that("getBetaFromDoubling gives meaningful result if doubling.time <= 0", {
+  b1 <- getBetaFromDoubling(0, 1)
+  b2 <- getBetaFromDoubling(-1, 1)
+  expect_equal(b1, Inf)
+  expect_equal(b2, 0.5)
+})


### PR DESCRIPTION
Closes #66. I've added several tests for the `getBetaFromDoubling()` function. They are all written to test the behavior of the function as it's currently written. @jpspeng, could you verify that these different cases are behaving as intended, especially that the function can accept negative doubling times?