### PR TITLE
Remove magrittr from Imports in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,5 @@ Imports:
     shinyalert,
     shinyjs,
     urlshorteneR,
-    magrittr,
     tidyr
 RoxygenNote: 7.1.0


### PR DESCRIPTION
de9dc8faddb4495c98f9d4284404833831a5c37e removed the use of magrittr from the package, but it was still listed as a dependency in the DESCRIPTION file; this removes it.