### PR TITLE
Change wording and fix parameter toggle

### DIFF
--- a/R/helper.R
+++ b/R/helper.R
@@ -264,7 +264,7 @@ findBestRe <-
 #'
 #' This takes as input an intervention dataframe (int.table). The dataframe should have as
 #' columns 'Day' number, new intervention metric (either New.Re or New.Double.Time)
-#' and the number of days that the intervention is smoothed over (Days.of.Smoothing).
+#' and the number of days that the intervention is smoothed over (Days.to.Reach.New.Re).
 #'
 #' The function also takes as input a gamma value a flag for whether doubling time or is
 #' used as the metric (usedouble).
@@ -272,7 +272,7 @@ findBestRe <-
 #' It returns a vector of beta values that correspond with the intervention dataframe.
 #'
 #' @param int.table Dataframe with columns: Day, New.Re (or New.Double.Time), and
-#' Days.of.Smoothing
+#' Days.to.Reach.New.Re
 #' @param gamma Numeric.
 #' @param usedouble Boolean. TRUE if doubling time is used as the metric.
 #'
@@ -299,7 +299,7 @@ create.beta.vec <- function(int.table, gamma, usedouble) {
   rep.vec <-
     day.vec[2:length(day.vec)] - day.vec[1:length(day.vec) - 1]
   betas <- int.table.temp$beta[1:length(day.vec) - 1]
-  smooth.vec <- int.table.temp$Days.of.Smoothing
+  smooth.vec <- int.table.temp$Days.to.Reach.New.Re
 
   beta.vec <- c()
 
@@ -381,7 +381,7 @@ add.to.hist.table <-
 #'
 #' Bind rows to the intervention table.
 #'
-#' @param int.table Dataframe with Day, New.Re (or New.Double.Time), and Days.of.Smoothing
+#' @param int.table Dataframe with Day, New.Re (or New.Double.Time), and Days.to.Reach.New.Re
 #' columns.
 #' @param params List of parameters.
 #' @param usedouble Boolean. TRUE if doubling time is used in the app.
@@ -394,7 +394,7 @@ bind.to.intervention <- function(int.table, params, usedouble) {
       list(
         'Day' = params$int.new.num.days ,
         'New.Double.Time' = params$int.new.double,
-        'Days.of.Smoothing' = params$int.smooth.days
+        'Days.to.Reach.New.Re' = params$int.smooth.days
       )
     )
   }
@@ -404,7 +404,7 @@ bind.to.intervention <- function(int.table, params, usedouble) {
       list(
         'Day' = params$int.new.num.days,
         'New.Re' = params$int.new.r0,
-        'Days.of.Smoothing' = params$int.smooth.days
+        'Days.to.Reach.New.Re' = params$int.smooth.days
       )
     )
   }

--- a/R/models/model0_params.R
+++ b/R/models/model0_params.R
@@ -27,19 +27,18 @@ default.params <- list(
 
 
 # modal to enter parameters that pops up after clicking on "Customize Other Parameters"
-parameters.page <- function(params) {
-  params.page <- fluidPage(
-      incubation.period.input(params$incubation.period),
-      illness.length.input(params$illness.length),
-      hosp.after.inf.input(params$inf.to.hosp),
-      hosp.rate.input(params$hosp.rate),
-      hosp.los.input.model0(params$hosp.los),
-      icu.rate.input(params$icu.rate),
-      vent.rate.input(params$vent.rate)
-    )
-
-  params.page
+parameters.page <- function(){
+  fluidPage(
+    incubation.period.input(default.params$incubation.period),
+    illness.length.input(default.params$illness.length),
+    hosp.after.inf.input(default.params$inf.to.hosp),
+    hosp.rate.input(default.params$hosp.rate),
+    hosp.los.input.model0(default.params$hosp.los),
+    icu.rate.input(default.params$icu.rate),
+    vent.rate.input(default.params$vent.rate)
+  )
 }
+
 
 
 #' Process parameters for export

--- a/R/models/model1_params.R
+++ b/R/models/model1_params.R
@@ -27,22 +27,20 @@ default.params <- list(
 )
 
 # modal to enter parameters that pops up after clicking on "Customize Other Parameters"
-parameters.page <- function(params) {
-  params.page <- fluidPage(
-      incubation.period.input(params$incubation.period),
-      illness.length.input(params$illness.length),
-      hosp.rate.input(params$hosp.rate),
-      icu.rate.input(params$icu.rate),
-      vent.rate.input(params$vent.rate),
-      hosp.after.inf.input(params$hosp.delay.time),
-      icu.after.hosp.input(params$icu.delay.time),
-      vent.after.icu.input(params$vent.delay.time),
-      hosp.los.input(params$hosp.los),
-      icu.los.input(params$icu.los),
-      vent.los.input(params$vent.los)
-    )
-
-  params.page
+parameters.page <- function(){
+  fluidPage(
+      incubation.period.input(default.params$incubation.period),
+      illness.length.input(default.params$illness.length),
+      hosp.rate.input(default.params$hosp.rate),
+      icu.rate.input(default.params$icu.rate),
+      vent.rate.input(default.params$vent.rate),
+      hosp.after.inf.input(default.params$hosp.delay.time),
+      icu.after.hosp.input(default.params$icu.delay.time),
+      vent.after.icu.input(default.params$vent.delay.time),
+      hosp.los.input(default.params$hosp.los),
+      icu.los.input(default.params$icu.los),
+      vent.los.input(default.params$vent.los)
+      )
 }
 
 

--- a/R/models/model2_params.R
+++ b/R/models/model2_params.R
@@ -31,54 +31,52 @@ default.params <- list(
 )
 
 # modal to enter parameters that pops up after clicking on "Customize Other Parameters"
-parameters.page <- function(params) {
-  params.page <- fluidPage(
-      incubation.period.input(params$incubation.period),
-      hosp.rate.input(params$hosp.rate),
-      illness.length.input(params$illness.length),
-      hosp.after.inf.input(params$inf.to.hosp),
+parameters.page <- function(){
+  fluidPage(
+      incubation.period.input(default.params$incubation.period),
+      hosp.rate.input(default.params$hosp.rate),
+      illness.length.input(default.params$illness.length),
+      hosp.after.inf.input(default.params$inf.to.hosp),
 
       HTML(g.trans.prob.head),
       trans.prob.slider(
         inputId = 'p.g_icu',
         label = g.to.icu.wording,
-        value = params$p.g_icu
+        value = default.params$p.g_icu
       ),
       trans.prob.slider(
         inputId = 'p.g_d',
         label = g.to.disc.wording,
-        value = params$p.g_d
+        value = default.params$p.g_d
       ),
 
       HTML(icu.trans.prob.head),
       trans.prob.slider(
         inputId = 'p.icu_g',
         label = icu.to.g.wording,
-        value = params$p.icu_g
+        value = default.params$p.icu_g
       ),
       trans.prob.slider(
         inputId = 'p.icu_v',
         label = icu.to.vent.wording,
-        value = params$p.icu_v
+        value = default.params$p.icu_v
       ),
 
       HTML(vent.trans.prob.head),
       trans.prob.slider(
         inputId = 'p.v_icu',
         label = vent.to.icu.wording,
-        value = params$p.v_icu
+        value = default.params$p.v_icu
       ),
       trans.prob.slider(
         inputId = 'p.v_m',
         label = vent.to.m.wording,
-        value = params$p.v_m,
+        value = default.params$p.v_m,
         min = 0,
         max = 0.2,
         step = 0.001
       )
     )
-
-  params.page
 }
 
 

--- a/R/server.R
+++ b/R/server.R
@@ -153,12 +153,10 @@ server <- function(input, output, session) {
         }
         else if (as.character(input$date.hist) %in% as.character(hist.data()$Date))
             (
-                showNotification(re.warning.date.repeat,
-                                 type = "error")
+                shinyalert::shinyalert(re.warning.date.repeat, type = "error")
             )
         else{
-            showNotification(re.warning.blank.num,
-                             type = "error")
+            shinyalert::shinyalert(re.warning.blank.num, type = "error")
         }
     })
 
@@ -241,8 +239,7 @@ server <- function(input, output, session) {
 
         }
         else{
-            showNotification(re.warning.more.data,
-                             type = "error")
+            shinyalert::shinyalert(re.warning.more.data, type = "error")
         }
 
     })
@@ -474,7 +471,7 @@ server <- function(input, output, session) {
         }
 
         else{
-            showNotification(double.int.warning, type = 'error')
+            shinyalert::shinyalert(double.int.warning, type = "error")
         }
     })
 
@@ -899,11 +896,11 @@ server <- function(input, output, session) {
         name <- trimws(input$freeze_name)
         selected <- input$selected_lines
         if (name == selected) {
-            shinyalert::shinyalert("Can't use the same name as the selected variable.", type = "error")
+            shinyalert::shinyalert("You cannot use the same name as the selected variable.", type = "error")
             return()
         }
         if (name %in% unique(frozen_lines()$variable)) {
-            shinyalert::shinyalert("Can't use the same name twice.", type = "error")
+            shinyalert::shinyalert("You cannot use the same name twice.", type = "error")
             return()
         }
         cols <- c("date", selected)

--- a/R/server.R
+++ b/R/server.R
@@ -397,13 +397,13 @@ server <- function(input, output, session) {
     int.df.with.re <- data.frame(
         'Day' = numeric(0),
         'New Re' = numeric(0),
-        'Days of Smoothing' =  numeric(0)
+        'Days to Reach New Re' =  numeric(0)
     )
 
     int.df.with.double <- data.frame(
         'Day' = numeric(0),
         'New Double Time' = numeric(0),
-        'Days of Smoothing' =  numeric(0)
+        'Days to Reach New Re' =  numeric(0)
     )
 
     intervention.table <- reactiveVal(int.df.with.re)
@@ -484,15 +484,15 @@ server <- function(input, output, session) {
             int.df <-
                 int.df[, c('Date',
                            'New.Double.Time',
-                           'Days.of.Smoothing',
+                           'Days.to.Reach.New.Re',
                            'Day')]
             colnames(int.df) <-
-                c('Date', 'New Double Time', 'Days of Smoothing', 'Day')
+                c('Date', 'New Double Time', 'Days to Reach New Re', 'Day')
         }
         else{
-            int.df <- int.df[, c('Date', 'New.Re', 'Days.of.Smoothing', 'Day')]
+            int.df <- int.df[, c('Date', 'New.Re', 'Days.to.Reach.New.Re', 'Day')]
             colnames(int.df) <-
-                c('Date', 'New Re', 'Days of Smoothing', 'Day')
+                c('Date', 'New Re', 'Days to Reach New Re', 'Day')
         }
 
         if (nrow(int.df) > 0) {
@@ -568,7 +568,7 @@ server <- function(input, output, session) {
                                                 input$proj_num_days
                                             ),
                                             New.Re = c(params$int.new.r0, input$r0_prior, NA),
-                                            Days.of.Smoothing = c(params$int.smooth.days, 0, 0)
+                                            Days.to.Reach.New.Re = c(params$int.smooth.days, 0, 0)
                                         ),
                                         int.table.temp)
             }
@@ -576,7 +576,7 @@ server <- function(input, output, session) {
                 int.table.temp <- rbind(list(
                                             Day = c(-curr.day, input$proj_num_days),
                                             New.Re = c(r0.default, NA),
-                                            Days.of.Smoothing = c(0, 0)
+                                            Days.to.Reach.New.Re = c(0, 0)
                                         ),
                                         int.table.temp)
             }
@@ -591,7 +591,7 @@ server <- function(input, output, session) {
                         input$proj_num_days
                     ),
                     New.Double.Time = c(params$int.new.double, input$doubling_time, NA),
-                    Days.of.Smoothing = c(params$int.smooth.days, 0, 0)
+                    Days.to.Reach.New.Re = c(params$int.smooth.days, 0, 0)
                 ),
                 int.table.temp
             )

--- a/R/server.R
+++ b/R/server.R
@@ -284,7 +284,7 @@ server <- function(input, output, session) {
 
         div(
             HTML("<br><h4><b>Parameters</b></h4><br>"),
-            isolate(model())$parameters.page(params)
+            isolate(model())$parameters.page()
         )
     })
 

--- a/R/server.R
+++ b/R/server.R
@@ -540,24 +540,11 @@ server <- function(input, output, session) {
     ##  Influx of Infections
     ##  ............................................................................
 
-    output$influx_ui <- renderUI({
-        if (input$showinflux) {
-            div(
-                dateInput(
-                    inputId = 'influx_date',
-                    label = "Date of Influx",
-                    min = input$curr_date,
-                    value = input$curr_date
-                ),
-                numericInput('num.influx',
-                             label =  "Number of Infected Entering Region",
-                             value = 0)
-                
-            )
-        }
-
+    observeEvent(input$curr_date, {
+        updateDateInput(session,
+                        inputId = 'influx_date',
+                        min = input$curr_date)
     })
-
     ##  ............................................................................
     ##  Projection
     ##  ............................................................................

--- a/R/ui.R
+++ b/R/ui.R
@@ -119,7 +119,21 @@ ui <- function(req) {
                                 
                                 checkboxInput(inputId = 'showinflux', label = 'Add Influx of Infected Individuals'),
                                 
-                                uiOutput(outputId = 'influx_ui'),
+                                conditionalPanel(
+                                  "input$showinflux == true",
+                                  div(
+                                    dateInput(
+                                      inputId = 'influx_date',
+                                      label = "Date of Influx",
+                                      min = Sys.Date(),
+                                      value =  Sys.Date()
+                                    ),
+                                    numericInput('num.influx',
+                                                 label =  "Number of Infected Entering Region",
+                                                 value = 0)
+                                    
+                                  )
+                                ),
                                 
                                 tags$hr(),
                                 

--- a/R/ui.R
+++ b/R/ui.R
@@ -102,7 +102,7 @@ ui <- function(req) {
                                   ),
                                   sliderInput(
                                     'smooth.int',
-                                    label = "Smoothed over how many days?",
+                                    label = "Days to Reach New Re",
                                     value = 0,
                                     min = 0,
                                     max = 30


### PR DESCRIPTION
Changes the wording from "Days of Smoothing" to "Days to Reach New Re" and fixes parameter toggle bug. (resolves https://github.com/lemdt/CovidShinyModel/issues/76, https://github.com/lemdt/CovidShinyModel/issues/78)

Note that the resolution to the parameter toggle is a bandaid fix. The parameters structure between models will be rewritten. 

Also: 
1) Changed some words on some notifications, and using shinyalert package instead of standard Shiny notifications. 
2) Put influx into a conditional panel instead of using a uiOutput. (based on suggestion of best practice from Dean) 